### PR TITLE
fixed typo on `util` import. removed `fig.tightlayout` in example.

### DIFF
--- a/examples/plot_all_styles.py
+++ b/examples/plot_all_styles.py
@@ -49,7 +49,7 @@ def test_artists_plot():
     axes[3].set_ylabel('y-label')
     axes[3].set_title('title')
 
-    fig.tight_layout()
+    #fig.tight_layout()
     # `colorbar` should be called after `tight_layout`.
     fig.colorbar(img, ax=axes[1])
     return fig

--- a/mpltools/__init__.py
+++ b/mpltools/__init__.py
@@ -25,7 +25,7 @@ config
     Dictionary of package configuration settings.
 
 """
-from utils import *
+from util import *
 
 import os.path as _osp
 pkgdir = _osp.abspath(_osp.dirname(__file__))


### PR DESCRIPTION
the util module was mistakenly imported as `utils`. not sure which is correct,
so i picked one.

the `tightlayout` figure function is not available in my version of
matplotlib (1.0.1-3), perhaps a test for version could be
included.
