### PR TITLE
ggplot style drawing linewidth

### DIFF
--- a/mpltools/style/ggplot.rc
+++ b/mpltools/style/ggplot.rc
@@ -1,6 +1,6 @@
 # from http://www.huyng.com/posts/sane-color-scheme-for-matplotlib/
 
-patch.linewidth = '0.5'
+patch.linewidth = 0.5
 patch.facecolor = '#348ABD'  # blue
 patch.edgecolor = '#EEEEEE'
 patch.antialiased = True


### PR DESCRIPTION
Hello Tony,

The ggplot.rc style fails when drawings are called by matplotlib, due to a float expected for the patch.linewidth parameter.

```
patch.linewidth = '0.5'
```

changed to 

```
patch.linewidth = 0.5
```

Thank you for this nice library !

Guillaume
