### PR TITLE
Some modification on errorfill

### DIFF
--- a/mpltools/special/errorfill.py
+++ b/mpltools/special/errorfill.py
@@ -7,8 +7,8 @@ import matplotlib.pyplot as plt
 __all__ = ['errorfill']
 
 
-def errorfill(x, y, yerr=None, xerr=None, color=None, ls=None, alpha=1, alpha_fill=0.3,
-              label='', label_fill='', ax=None):
+def errorfill(x, y, yerr=None, xerr=None, color=None, ls=None, lw=None,
+              alpha=1, alpha_fill=0.3, label='', label_fill='', ax=None):
     """Plot data with errors marked by a filled region.
 
     Parameters
@@ -22,6 +22,8 @@ def errorfill(x, y, yerr=None, xerr=None, color=None, ls=None, alpha=1, alpha_fi
         Color of line and fill region.
     ls : Matplotlib line style
         Style of the line
+    lw : Matplotlib line width, float value in points
+        Width of the line
     alpha : float
         Opacity used for plotting.
     alpha_fill : float
@@ -41,8 +43,10 @@ def errorfill(x, y, yerr=None, xerr=None, color=None, ls=None, alpha=1, alpha_fi
     if color is None:
         color = ax._get_lines.color_cycle.next()
     if ls is None:
-        ls = '-'
-    ax.plot(x, y, color, linestyle=ls, alpha=alpha, label=label)
+        ls = plt.rcParams['lines.linestyle']
+    if lw is None:
+        lw = plt.rcParams['lines.linewidth']
+    ax.plot(x, y, color, linestyle=ls, linewidth=lw, alpha=alpha, label=label)
 
     if yerr is not None and xerr is not None:
         msg = "Setting both `yerr` and `xerr` is not supported. Ignore `xerr`."


### PR DESCRIPTION
lines 34-35: 'ax' added in the doc string (was missing) 
lines 10, 23-24, 43-45: line style for the line x,y added: now it is possible to use a line style passed to the function
line 45 indentation corrected: before was drawing the line only if color is None
