### PR TITLE
special/errorfill.py: error in help string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,3 @@ mpltools.egg-info
 examples/test*
 doc/source/auto_examples
 doc/source/api
-.*.un~
-.*.swp


### PR DESCRIPTION
The second 'label : str' should be 'label_fill : str'.

I have modified the .gitignore to ignore swap (_.swp) and permanent undo (_.un~) files created by vim 
