### PR TITLE
correct use of future_builtin

### DIFF
--- a/mpltools/special/hinton.py
+++ b/mpltools/special/hinton.py
@@ -1,5 +1,5 @@
 from __future__ import division
-from future.builtins import zip
+from future_builtins import zip
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib import collections


### PR DESCRIPTION
on linux mint 17 with Python 2.7.6 (default, Mar 22 2014, 22:59:56) 
```
import future_builtins

future_builtins?
Type:        module
String form: <module 'future_builtins' from '/usr/lib/python2.7/lib-dynload/future_builtins.x86_64-linux-gnu.so'>
File:        /usr/lib/python2.7/lib-dynload/future_builtins.x86_64-linux-gnu.so
Docstring:
This module provides functions that will be builtins in Python 3.0,
but that conflict with builtins that already exist in Python 2.x.

Functions:

ascii(arg) -- Returns the canonical string representation of an object.
filter(pred, iterable) -- Returns an iterator yielding those items of 
       iterable for which pred(item) is true.
hex(arg) -- Returns the hexadecimal representation of an integer.
map(func, *iterables) -- Returns an iterator that computes the function 
    using arguments from each of the iterables.
oct(arg) -- Returns the octal representation of an integer.
zip(iter1 [,iter2 [...]]) -- Returns a zip object whose .next() method 
    returns a tuple where the i-th element comes from the i-th iterable 
    argument.

The typical usage of this module is to replace existing builtins in a
module's namespace:
 
from future_builtins import ascii, filter, map, hex, oct, zip
```