### PR TITLE
fixed TypeError for crange

### DIFF
--- a/mpltools/color.py
+++ b/mpltools/color.py
@@ -166,7 +166,7 @@ def colors_from_cmap(length=50, cmap=None, start=None, stop=None):
     if isinstance(cmap, str):
         cmap = getattr(plt.cm, cmap)
 
-    crange = CMAP_RANGE.get(cmap.name, (0, 1))
+    crange = list(CMAP_RANGE.get(cmap.name, (0, 1)))
     if start is not None:
         crange[0] = start
     if stop is not None:


### PR DESCRIPTION
made crange a list just as in the color_mapper function

Example:
    import mpltools.color as color
    colors = color.colors_from_cmap(10, cmap='gnuplot', stop=0.8)
Return:
    TypeError: 'tuple' object does not support item assignment